### PR TITLE
Add chrome bar header, /craft and /now routes, restructure as product…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,60 @@
+# Site TODO
+
+Things mentioned in conversation but not yet built — to focus on day-to-day.
+
+## Content I need from you
+
+- [ ] **Tia images** — currently using `/images/Intripid.png` as placeholder.
+      Need real Tia screenshots for the home page work card.
+- [ ] **Real Tia link** — `dev.intripid.co` is the placeholder. Update once
+      there's a public landing page.
+- [ ] **Real `/now` data** — the placeholders in `pages/now.js` (`NOW_DATA`)
+      need to be replaced with actual current state. Update monthly.
+- [ ] **More `/craft` entries** — only one sample exists
+      (`content/craft/openclaw-shell-agent.mdx`). The whole point of /craft
+      is the rolling feed of AI experiments / weekend builds.
+      Pattern to follow: short title, 1-paragraph description, status dot,
+      tags, optional demo + source links.
+
+## Features to build later
+
+- [ ] **Subdomain previous versions** — `2022.ssaisreenivas.in`,
+      `2023.ssaisreenivas.in`, etc. Each hosts a frozen snapshot of the
+      site at that time. Rauno does this and it's a great signal of
+      "I've been at this for years."
+- [ ] **Photo gallery / photographer side** — Rauno-inspired horizontal
+      gallery showcasing the photography side. Probably lives at `/photos`
+      or as a section on `/craft`. Decide later.
+- [ ] **Brian Lovin-style detailed project showcase** — case study pages
+      for major work entries (Tia, Intripid, LeafCraft, Datametrix).
+      Each gets its own URL with full writeup, screenshots, role,
+      challenges, outcome. Lives at `/work/[slug]` probably.
+- [ ] **`/stack` or `/uses` page** — hardware, editor, fonts, terminal
+      setup, productivity tools. Very builder-coded.
+
+## Craft / polish details
+
+- [ ] **View Transitions API** — smooth page-to-page fades like leerob.io.
+- [ ] **⌘K command palette** — keyboard navigation. `g h` → home, `g c` →
+      craft, `g w` → writing, etc.
+- [ ] **RSS feed** for `/blog` and `/craft`. Add `<link rel="alternate">`
+      to head. Visible "Subscribe via RSS" link in footer.
+- [ ] **"Last shipped" timestamp** in the header status chip — auto-pulled
+      from latest commit or latest /craft entry.
+- [ ] **Reading time** on blog and craft posts.
+
+## Craft frontmatter schema (for reference)
+
+```yaml
+---
+title: "..."                    # required
+date: "YYYY-MM-DD"              # required
+description: "..."              # required, 1 sentence
+tags: ["AI", "Tools"]           # optional
+status: "wip" | "shipped" | "exploring"  # required
+type: "experiment" | "tool" | "demo" | "thought"  # optional
+demoLink: "https://..."         # optional
+sourceLink: "https://github..." # optional
+cover: "/images/craft/..."      # optional
+---
+```

--- a/content/craft/openclaw-shell-agent.mdx
+++ b/content/craft/openclaw-shell-agent.mdx
@@ -1,0 +1,26 @@
+---
+title: "OpenClaw Shell Agent"
+date: "2026-03-22"
+description: "A local-first agent that runs shell scripts triggered from WhatsApp voice notes."
+tags: ["AI", "Agents", "Local-first"]
+status: "wip"
+type: "experiment"
+demoLink: ""
+sourceLink: ""
+cover: ""
+---
+
+## The idea
+
+Every time I'm out and remember a command I should've run on my dev machine, I have to wait until I'm back at the laptop. This agent listens for WhatsApp voice notes, transcribes them, and runs the matching shell script locally — no SSH, no friction.
+
+## How it works
+
+1. WhatsApp message → webhook
+2. Whisper transcribes
+3. A small LLM matches intent to a script in `~/openclaw/scripts`
+4. Confirmation reply with stdout
+
+## Status
+
+Working prototype on macOS. Still figuring out the auth model for letting an LLM execute commands without it being terrifying.

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,10 @@
-import { Box, ChakraProvider, Container } from "@chakra-ui/react";
+import { ChakraProvider, Container } from "@chakra-ui/react";
 
 import theme from "../src/Theme";
 import { Chakra } from "../src/chakra";
 import "../styles/globals.css";
 import Fonts from "../styles/Theme/fonts";
-import { BottomPortion, TopLine } from "../src/components/CustomComponents";
+import { BottomPortion } from "../src/components/CustomComponents";
 import Header from "../src/components/Header";
 
 function MyApp({ Component, pageProps, cookies }) {
@@ -12,11 +12,9 @@ function MyApp({ Component, pageProps, cookies }) {
     <>
       <Chakra cookies={cookies}>
         <ChakraProvider theme={theme}>
-          <TopLine />
+          <Fonts />
+          <Header />
           <Container maxW="1080px" mx="auto">
-            <Header />
-
-            <Fonts />
             <Component {...pageProps} />
           </Container>
           <BottomPortion />

--- a/pages/craft/[slug].js
+++ b/pages/craft/[slug].js
@@ -1,0 +1,285 @@
+import {
+  Box,
+  Container,
+  VStack,
+  HStack,
+  Text,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import { serialize } from "next-mdx-remote/serialize";
+import { MDXRemote } from "next-mdx-remote";
+import Head from "next/head";
+import Link from "next/link";
+
+import { getCraftSlugs, getCraftBySlug } from "../../src/lib/craft";
+import {
+  CustomText,
+  SectionLabel,
+} from "../../src/components/CustomComponents";
+
+const STATUS_LABEL = {
+  wip: "Work in progress",
+  shipped: "Shipped",
+  exploring: "Exploring",
+};
+
+const StatusDot = ({ status }) => {
+  const color =
+    status === "shipped"
+      ? "#4ade80"
+      : status === "wip"
+      ? "#fbbf24"
+      : "#94a3b8";
+  return (
+    <Box
+      w="6px"
+      h="6px"
+      borderRadius="full"
+      bg={color}
+      boxShadow={`0 0 8px ${color}55`}
+    />
+  );
+};
+
+const components = {
+  h1: (props) => (
+    <Text
+      as="h1"
+      fontFamily="MonolisaBold"
+      fontSize={{ base: "22px", md: "26px" }}
+      color="white"
+      mt={12}
+      mb={4}
+      lineHeight="1.3"
+      letterSpacing="-0.3px"
+      {...props}
+    />
+  ),
+  h2: (props) => (
+    <Text
+      as="h2"
+      fontFamily="MonolisaBold"
+      fontSize={{ base: "18px", md: "20px" }}
+      color="white"
+      mt={10}
+      mb={3}
+      lineHeight="1.3"
+      {...props}
+    />
+  ),
+  h3: (props) => (
+    <Text
+      as="h3"
+      fontFamily="MonolisaBold"
+      fontSize={{ base: "15px", md: "16px" }}
+      color="white"
+      mt={8}
+      mb={3}
+      lineHeight="1.4"
+      {...props}
+    />
+  ),
+  p: (props) => (
+    <Text
+      my={4}
+      fontSize={{ base: "13px", md: "14px" }}
+      lineHeight="2"
+      color="#B0B0B0"
+      fontFamily="MonolisaRegular"
+      {...props}
+    />
+  ),
+  ul: (props) => <Box as="ul" ml={5} my={4} color="#B0B0B0" {...props} />,
+  ol: (props) => <Box as="ol" ml={5} my={4} color="#B0B0B0" {...props} />,
+  li: (props) => (
+    <Box
+      as="li"
+      my={2}
+      fontSize={{ base: "13px", md: "14px" }}
+      lineHeight="1.9"
+      fontFamily="MonolisaRegular"
+      {...props}
+    />
+  ),
+  strong: (props) => (
+    <Text as="strong" color="white" fontFamily="MonolisaBold" {...props} />
+  ),
+  code: (props) => (
+    <Box
+      as="code"
+      bg="whiteAlpha.100"
+      px={2}
+      py={1}
+      borderRadius="4px"
+      fontSize="0.9em"
+      color="white"
+      fontFamily="MonolisaRegular"
+      {...props}
+    />
+  ),
+};
+
+const MetaRow = ({ label, children }) => (
+  <Box>
+    <Text
+      fontSize="9px"
+      fontFamily="MonolisaRegular"
+      color="dim"
+      textTransform="uppercase"
+      letterSpacing="1.5px"
+      mb={1}
+    >
+      {label}
+    </Text>
+    <Box fontSize="12px" fontFamily="MonolisaRegular" color="white">
+      {children}
+    </Box>
+  </Box>
+);
+
+export default function CraftPost({ source, frontmatter }) {
+  const dateStr = new Date(frontmatter.date).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <>
+      <Head>
+        <title>{frontmatter.title} — Craft / Sreenivas Sonthena</title>
+        <meta name="description" content={frontmatter.description} />
+        <meta name="twitter:creator" content="@sreeeeenivas" />
+      </Head>
+
+      <Container maxW="full" px={4} pt={{ base: 10, md: 16 }} pb={20}>
+        <Box maxW="720px">
+          <VStack align="start" spacing={3} mb={8}>
+            <Link href="/craft" passHref>
+              <Text
+                as="span"
+                fontSize="10px"
+                fontFamily="MonolisaRegular"
+                color="ash"
+                letterSpacing="2px"
+                textTransform="uppercase"
+                cursor="pointer"
+                _hover={{ color: "white" }}
+              >
+                ← back to craft
+              </Text>
+            </Link>
+
+            <HStack spacing={2}>
+              <StatusDot status={frontmatter.status} />
+              <Text
+                fontSize="10px"
+                fontFamily="MonolisaRegular"
+                color="dim"
+                letterSpacing="0.5px"
+              >
+                {STATUS_LABEL[frontmatter.status] || "Note"}
+              </Text>
+              <Text
+                fontSize="10px"
+                fontFamily="MonolisaRegular"
+                color="ash"
+                letterSpacing="0.5px"
+              >
+                · {dateStr}
+              </Text>
+            </HStack>
+
+            <Text
+              as="h1"
+              fontFamily="MonolisaBold"
+              fontSize={{ base: "24px", md: "30px" }}
+              lineHeight="1.2"
+              letterSpacing="-0.5px"
+              color="white"
+            >
+              {frontmatter.title}
+            </Text>
+
+            <CustomText lineHeight="1.8">
+              {frontmatter.description}
+            </CustomText>
+          </VStack>
+
+          <Box h="1px" bg="whiteAlpha.100" mb={8} />
+
+          {/* Meta */}
+          {(frontmatter.tags?.length || frontmatter.demoLink || frontmatter.sourceLink) && (
+            <SimpleGrid columns={{ base: 1, sm: 3 }} spacing={5} mb={10}>
+              {frontmatter.tags?.length > 0 && (
+                <MetaRow label="TAGS">
+                  <HStack spacing={1.5} flexWrap="wrap">
+                    {frontmatter.tags.map((t) => (
+                      <Text
+                        key={t}
+                        as="span"
+                        fontSize="11px"
+                        color="white"
+                      >
+                        {t}
+                      </Text>
+                    ))}
+                  </HStack>
+                </MetaRow>
+              )}
+              {frontmatter.demoLink && (
+                <MetaRow label="DEMO">
+                  <Link href={frontmatter.demoLink} target="_blank">
+                    <Text
+                      as="span"
+                      textDecoration="underline"
+                      textDecorationColor="whiteAlpha.400"
+                      textUnderlineOffset="3px"
+                      _hover={{ textDecorationColor: "white" }}
+                    >
+                      open ↗
+                    </Text>
+                  </Link>
+                </MetaRow>
+              )}
+              {frontmatter.sourceLink && (
+                <MetaRow label="SOURCE">
+                  <Link href={frontmatter.sourceLink} target="_blank">
+                    <Text
+                      as="span"
+                      textDecoration="underline"
+                      textDecorationColor="whiteAlpha.400"
+                      textUnderlineOffset="3px"
+                      _hover={{ textDecorationColor: "white" }}
+                    >
+                      github ↗
+                    </Text>
+                  </Link>
+                </MetaRow>
+              )}
+            </SimpleGrid>
+          )}
+
+          {/* Article body */}
+          <Box>
+            <MDXRemote {...source} components={components} />
+          </Box>
+        </Box>
+      </Container>
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  const slugs = getCraftSlugs();
+  const paths = slugs.map((slug) => ({
+    params: { slug: slug.replace(/\.mdx?$/, "") },
+  }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }) {
+  const { content, frontmatter } = getCraftBySlug(params.slug);
+  const mdxSource = await serialize(content);
+  return { props: { source: mdxSource, frontmatter } };
+}

--- a/pages/craft/index.js
+++ b/pages/craft/index.js
@@ -1,0 +1,185 @@
+import {
+  Box,
+  Container,
+  VStack,
+  SimpleGrid,
+  Text,
+  HStack,
+} from "@chakra-ui/react";
+import Head from "next/head";
+import Link from "next/link";
+
+import {
+  CustomText,
+  SectionLabel,
+} from "../../src/components/CustomComponents";
+import { getAllCraft } from "../../src/lib/craft";
+
+const STATUS_LABEL = {
+  wip: "Work in progress",
+  shipped: "Shipped",
+  exploring: "Exploring",
+};
+
+const StatusDot = ({ status }) => {
+  const color =
+    status === "shipped"
+      ? "#4ade80"
+      : status === "wip"
+      ? "#fbbf24"
+      : "#94a3b8";
+  return (
+    <Box
+      w="6px"
+      h="6px"
+      borderRadius="full"
+      bg={color}
+      boxShadow={`0 0 8px ${color}55`}
+    />
+  );
+};
+
+const CraftCard = ({ item }) => {
+  const { frontmatter, slug } = item;
+  return (
+    <Link href={`/craft/${slug}`} passHref style={{ textDecoration: "none" }}>
+      <Box
+        p={5}
+        border="1px solid"
+        borderColor="whiteAlpha.100"
+        borderRadius="12px"
+        transition="all 0.3s ease"
+        _hover={{
+          transform: "translateY(-3px)",
+          borderColor: "whiteAlpha.300",
+        }}
+        height="full"
+        cursor="pointer"
+        role="group"
+      >
+        <VStack align="start" spacing={3}>
+          <HStack spacing={2}>
+            <StatusDot status={frontmatter.status} />
+            <Text
+              fontSize="10px"
+              fontFamily="MonolisaRegular"
+              color="dim"
+              letterSpacing="0.5px"
+            >
+              {STATUS_LABEL[frontmatter.status] || "Note"}
+            </Text>
+          </HStack>
+
+          <Text
+            fontSize="15px"
+            fontFamily="MonolisaBold"
+            color="white"
+            lineHeight="1.35"
+            _groupHover={{
+              textDecoration: "underline",
+              textDecorationColor: "whiteAlpha.400",
+              textUnderlineOffset: "3px",
+            }}
+            transition="0.2s"
+          >
+            {frontmatter.title}
+          </Text>
+
+          <CustomText noOfLines={3} lineHeight="1.7">
+            {frontmatter.description}
+          </CustomText>
+
+          {frontmatter.tags && frontmatter.tags.length > 0 && (
+            <HStack spacing={2} flexWrap="wrap">
+              {frontmatter.tags.map((tag) => (
+                <Text
+                  key={tag}
+                  fontSize="9px"
+                  color="ash"
+                  fontFamily="MonolisaRegular"
+                  px={2}
+                  py={0.5}
+                  border="1px solid"
+                  borderColor="whiteAlpha.100"
+                  borderRadius="full"
+                >
+                  {tag}
+                </Text>
+              ))}
+            </HStack>
+          )}
+
+          <Text
+            fontSize="10px"
+            color="ash"
+            fontFamily="MonolisaRegular"
+            letterSpacing="1px"
+            mt={1}
+          >
+            {new Date(frontmatter.date)
+              .toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })
+              .toUpperCase()}
+          </Text>
+        </VStack>
+      </Box>
+    </Link>
+  );
+};
+
+function CraftIndex({ items }) {
+  return (
+    <>
+      <Head>
+        <title>Craft — Sreenivas Sonthena</title>
+        <meta
+          name="description"
+          content="Experiments, side projects, and tinkering. Where I test ideas before they become anything real."
+        />
+        <meta name="twitter:creator" content="@sreeeeenivas" />
+      </Head>
+
+      <Container maxW="full" px={4} py={{ base: 10, md: 16 }}>
+        <VStack spacing={12} align="stretch">
+          <VStack align="start" spacing={4}>
+            <SectionLabel>CRAFT</SectionLabel>
+            <Text
+              fontFamily="MonolisaBold"
+              fontSize={{ base: "26px", md: "30px" }}
+              color="white"
+              letterSpacing="-0.5px"
+              lineHeight="1.2"
+            >
+              Things I&apos;m tinkering<br />with
+            </Text>
+            <CustomText maxW="560px" lineHeight="1.8">
+              Experiments, AI findings, weekend builds, and half-finished
+              ideas. The place where things start before they become real
+              projects.
+            </CustomText>
+          </VStack>
+
+          {items.length === 0 ? (
+            <CustomText>Nothing here yet. Soon.</CustomText>
+          ) : (
+            <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={5}>
+              {items.map((item) => (
+                <CraftCard key={item.slug} item={item} />
+              ))}
+            </SimpleGrid>
+          )}
+        </VStack>
+      </Container>
+    </>
+  );
+}
+
+export async function getStaticProps() {
+  const items = getAllCraft();
+  return { props: { items } };
+}
+
+export default CraftIndex;

--- a/pages/index.js
+++ b/pages/index.js
@@ -84,45 +84,34 @@ export default function Home({ posts }) {
       <div>
         {/* Hero */}
         <MotionBox initial="hidden" animate="visible" variants={fadeInUp}>
-          <Container maxW="full" px={4} pt={{ base: 8, md: 14, lg: 20 }}>
+          <Container maxW="full" px={4} pt={{ base: 8, md: 14, lg: 16 }}>
             <SectionLabel mb={5}>SREENIVAS SONTHENA</SectionLabel>
             <Text
               fontFamily="MonolisaBold"
-              fontSize={{ base: "22px", md: "28px", lg: "34px" }}
-              lineHeight="1.3"
+              fontSize={{ base: "22px", md: "28px", lg: "32px" }}
+              lineHeight="1.35"
               color="white"
-              letterSpacing="-0.8px"
+              letterSpacing="-0.6px"
               maxW="780px"
             >
-              I turn complex problems into{" "}
+              I build software products{" "}
               <AccentText textDecoration="underline" textDecorationColor="whiteAlpha.400" textUnderlineOffset="5px">
-                simple interfaces
-              </AccentText>{" "}
-              — from mechanical systems to AI-powered products.
+                end-to-end
+              </AccentText>
+              . Currently building Tia at Intripid, writing about AI, and
+              shipping experiments on the side.
             </Text>
           </Container>
         </MotionBox>
 
-        {/* Social + CTAs */}
+        {/* Contact stack — vertical, left-aligned */}
         <MotionBox
           initial="hidden"
           animate="visible"
           variants={{ ...fadeInUp, visible: { ...fadeInUp.visible, transition: { delay: 0.1, duration: 0.5, ease: "easeOut" } } }}
         >
-          <Container maxW="full" px={4}>
-            <Stack
-              direction={{ base: "column", md: "row" }}
-              spacing={{ base: "4", md: "10" }}
-              align={{ md: "center" }}
-            >
-              <HStack spacing={{ base: 5, md: 8 }} py={{ base: 5, md: 8 }}>
-                <CustomIkonButton variant="twitter" />
-                <CustomIkonButton variant="instagram" />
-                <CustomIkonButton variant="dribbble" />
-                <CustomIkonButton variant="linkedin" />
-                <CustomIkonButton variant="behance" />
-                <CustomIkonButton variant="github" />
-              </HStack>
+          <Container maxW="full" px={4} pt={{ base: 6, md: 8 }}>
+            <VStack align="start" spacing={4}>
               <HStack spacing={3}>
                 <CustomButton variant="themed" href="mailto:ssaisreenivas@gmail.com">
                   Get in touch →
@@ -131,7 +120,15 @@ export default function Home({ posts }) {
                   Read my writing
                 </CustomButton>
               </HStack>
-            </Stack>
+              <HStack spacing={5}>
+                <CustomIkonButton variant="twitter" />
+                <CustomIkonButton variant="instagram" />
+                <CustomIkonButton variant="dribbble" />
+                <CustomIkonButton variant="linkedin" />
+                <CustomIkonButton variant="behance" />
+                <CustomIkonButton variant="github" />
+              </HStack>
+            </VStack>
           </Container>
         </MotionBox>
 

--- a/pages/now.js
+++ b/pages/now.js
@@ -1,0 +1,191 @@
+import {
+  Box,
+  Container,
+  VStack,
+  HStack,
+  Text,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import Head from "next/head";
+
+import {
+  CustomText,
+  SectionLabel,
+} from "../src/components/CustomComponents";
+
+// TODO(now-page): keep these fields fresh — update monthly. Pull real data
+// from Spotify / Goodreads / GitHub later if we want it automated.
+const NOW_DATA = {
+  lastUpdated: "April 2026",
+  location: "Hyderabad, India",
+  building: {
+    title: "Tia at Intripid",
+    detail:
+      "Leading frontend for our AI travel assistant. Shipping the first end-to-end version this quarter.",
+  },
+  focus: [
+    "Frontend architecture for AI-first products",
+    "Agent design patterns and tool-use UX",
+    "Writing more — moving from notes to published posts",
+  ],
+  reading: [
+    { title: "The Pragmatic Engineer", by: "Gergely Orosz" },
+    { title: "Working in Public", by: "Nadia Eghbal" },
+  ],
+  shipping: [
+    "Tia v1 — internal beta",
+    "OpenClaw shell agent (see /craft)",
+    "Daily AI experiments cross-posted to X",
+  ],
+  notLearning: [
+    "Saying yes to things I shouldn't",
+    "Polishing instead of shipping",
+  ],
+};
+
+const Section = ({ label, children }) => (
+  <Box>
+    <SectionLabel mb={4}>{label}</SectionLabel>
+    {children}
+  </Box>
+);
+
+const ListBlock = ({ items }) => (
+  <VStack align="start" spacing={2}>
+    {items.map((item, i) => (
+      <HStack key={i} align="start" spacing={3}>
+        <Text
+          fontSize="13px"
+          color="ash"
+          fontFamily="MonolisaRegular"
+          mt="2px"
+        >
+          —
+        </Text>
+        <CustomText lineHeight="1.8">
+          {typeof item === "string" ? item : `${item.title} — ${item.by}`}
+        </CustomText>
+      </HStack>
+    ))}
+  </VStack>
+);
+
+const Now = () => {
+  return (
+    <>
+      <Head>
+        <title>Now — Sreenivas Sonthena</title>
+        <meta
+          name="description"
+          content="What I'm building, reading, and focused on right now. Updated monthly."
+        />
+        <meta name="twitter:creator" content="@sreeeeenivas" />
+      </Head>
+
+      <Container maxW="full" px={4} py={{ base: 10, md: 16 }}>
+        <Box maxW="720px">
+          <VStack align="start" spacing={12}>
+            {/* Header */}
+            <VStack align="start" spacing={4}>
+              <SectionLabel>NOW</SectionLabel>
+              <Text
+                fontFamily="MonolisaBold"
+                fontSize={{ base: "26px", md: "30px" }}
+                color="white"
+                letterSpacing="-0.5px"
+                lineHeight="1.2"
+              >
+                What I&apos;m doing<br />right now
+              </Text>
+              <CustomText lineHeight="1.8" maxW="560px">
+                A snapshot of where my attention is. Inspired by Derek
+                Sivers&apos; <a href="https://nownownow.com" target="_blank" rel="noopener noreferrer" style={{ textDecoration: "underline" }}>now page</a> idea — updated monthly so you know
+                this is current, not stale.
+              </CustomText>
+              <HStack spacing={4}>
+                <HStack spacing={2}>
+                  <Box
+                    w="6px"
+                    h="6px"
+                    borderRadius="full"
+                    bg="#4ade80"
+                    boxShadow="0 0 8px rgba(74,222,128,0.6)"
+                  />
+                  <Text
+                    fontSize="11px"
+                    fontFamily="MonolisaRegular"
+                    color="dim"
+                  >
+                    Updated {NOW_DATA.lastUpdated}
+                  </Text>
+                </HStack>
+                <Text
+                  fontSize="11px"
+                  fontFamily="MonolisaRegular"
+                  color="dim"
+                >
+                  · {NOW_DATA.location}
+                </Text>
+              </HStack>
+            </VStack>
+
+            <Box w="full" h="1px" bg="whiteAlpha.100" />
+
+            {/* Building */}
+            <Section label="BUILDING">
+              <Text
+                fontSize="16px"
+                fontFamily="MonolisaBold"
+                color="white"
+                mb={2}
+              >
+                {NOW_DATA.building.title}
+              </Text>
+              <CustomText lineHeight="1.8">
+                {NOW_DATA.building.detail}
+              </CustomText>
+            </Section>
+
+            {/* Focus */}
+            <Section label="FOCUS THIS MONTH">
+              <ListBlock items={NOW_DATA.focus} />
+            </Section>
+
+            {/* Shipping */}
+            <Section label="SHIPPING">
+              <ListBlock items={NOW_DATA.shipping} />
+            </Section>
+
+            {/* Reading */}
+            <Section label="READING">
+              <ListBlock items={NOW_DATA.reading} />
+            </Section>
+
+            {/* Saying no */}
+            <Section label="ACTIVELY SAYING NO TO">
+              <ListBlock items={NOW_DATA.notLearning} />
+            </Section>
+
+            <Box w="full" h="1px" bg="whiteAlpha.100" />
+
+            <CustomText fontSize="12px" lineHeight="1.7">
+              This page changes monthly. If you&apos;re reading something here
+              and it feels stale, ping me on{" "}
+              <a
+                href="https://x.com/sreeeeenivas"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "underline" }}
+              >
+                X
+              </a>{" "}
+              and I&apos;ll update it.
+            </CustomText>
+          </VStack>
+        </Box>
+      </Container>
+    </>
+  );
+};
+
+export default Now;

--- a/src/Data.js
+++ b/src/Data.js
@@ -1,5 +1,37 @@
 export const Data = [
   {
+    Name: "Tia by Intripid",
+    web: "intripid.com",
+    link: "https://dev.intripid.co/",
+    tags: [
+      {
+        name: "2025—26",
+        color: "gray",
+      },
+      {
+        name: "Tech Lead",
+        color: "purple",
+      },
+      {
+        name: "AI Assistant",
+        color: "blue",
+      },
+    ],
+
+    desc: [
+      {
+        data: "Leading frontend for Tia — Intripid's intelligent travel assistant. AI-powered conversations that turn vague travel ideas into bookable trips. Currently shipping the first version end-to-end.",
+      },
+    ],
+
+    images: [
+      {
+        src: "/images/Intripid.png",
+        words: "Tia AI travel assistant interface",
+      },
+    ],
+  },
+  {
     Name: "Intripid",
     web: "intripid.com",
     link: "https://dev.intripid.co/",

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,90 +1,169 @@
 import {
-  Center,
+  Box,
   Container,
   Flex,
+  HStack,
   Spacer,
-  Stack,
+  Text,
 } from "@chakra-ui/react";
 import Link from "next/link";
-import { CustomButton } from "./CustomComponents";
-import { Icon } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 
-const FavIcon = (props) => (
-  <Link href="/">
-    <Icon
-      width="104"
-      height="22"
-      viewBox="0 0 104 22"
-      {...props}
-      xmlns="http://www.w3.org/2000/svg"
+const NAV_ITEMS = [
+  { label: "home", href: "/" },
+  { label: "craft", href: "/craft" },
+  { label: "writing", href: "/blog" },
+  { label: "now", href: "/now" },
+  { label: "about", href: "/about" },
+];
+
+const StatusChip = () => (
+  <HStack
+    spacing={2}
+    px={2.5}
+    py={1}
+    border="1px solid"
+    borderColor="whiteAlpha.100"
+    borderRadius="full"
+    bg="whiteAlpha.50"
+  >
+    <Box
+      w="6px"
+      h="6px"
+      borderRadius="full"
+      bg="#4ade80"
+      boxShadow="0 0 8px rgba(74, 222, 128, 0.6)"
+    />
+    <Text
+      fontSize="10px"
+      fontFamily="MonolisaRegular"
+      color="dim"
+      letterSpacing="0.3px"
     >
-      <path
-        fill="currentcolor"
-        d="M1.82012 14.0733V16.363C3.08036 16.718 4.34059 16.8777 5.33458 16.8777C8.28105 16.8777 10.056 15.5642 10.056 13.1325C10.056 8.58856 3.9501 10.5943 3.9501 7.71882C3.9501 6.93783 4.41159 6.26334 6.00908 6.26334C6.91432 6.26334 7.99706 6.45858 9.45254 7.06208V4.80785C8.4053 4.36411 7.14506 4.09786 5.97358 4.09786C3.18686 4.09786 1.50062 5.51784 1.50062 7.96732C1.50062 12.458 7.62431 10.7008 7.62431 13.3633C7.62431 14.1088 7.10956 14.73 5.22808 14.73C4.1631 14.73 3.16911 14.5525 1.82012 14.0733ZM16.9545 16.8777C19.8832 16.8777 21.6049 14.872 21.6049 11.5173C21.6049 8.51756 20.0252 6.76033 17.3095 6.76033C14.3985 6.76033 12.659 8.76606 12.659 12.1208C12.659 15.1205 14.2387 16.8777 16.9545 16.8777ZM17.132 14.8187C15.5522 14.8187 15.002 14.0378 15.002 11.819C15.002 9.6003 15.5522 8.81931 17.132 8.81931C18.7117 8.81931 19.2619 9.6003 19.2619 11.819C19.2619 14.0378 18.7117 14.8187 17.132 14.8187ZM29.7991 6.76033C28.4501 6.76033 27.3141 7.47032 26.4266 8.71281L26.1426 6.93783H24.3499V16.7002H26.6041V10.2393C27.5271 9.10331 28.1484 8.67731 29.0358 8.67731C30.0298 8.67731 30.4381 9.20981 30.4381 10.257V16.7002H32.6746V9.8843C32.6746 7.82532 31.5918 6.76033 29.7991 6.76033ZM43.7797 8.85481V6.93783H39.6972V4.7546H37.869L37.4608 6.93783L35.4195 7.38157V8.85481H37.4608V13.381C37.4608 15.3335 38.6855 16.8777 41.2947 16.8777C42.1112 16.8777 42.9987 16.718 43.7797 16.4517V14.4105C43.0697 14.6767 42.3242 14.8187 41.6497 14.8187C40.212 14.8187 39.6972 14.233 39.6972 13.0615V8.85481H43.7797ZM52.5064 6.76033C51.2639 6.76033 50.2166 7.38157 49.4002 8.46431V3.56537H47.1637V16.7002H49.4002V10.2215C50.2876 9.10331 50.8911 8.67731 51.7254 8.67731C52.6484 8.67731 53.0211 9.20981 53.0211 10.257V16.7002H55.2753V9.8843C55.2753 7.82532 54.2281 6.76033 52.5064 6.76033ZM67.055 11.5528C67.055 8.53531 65.6527 6.76033 62.8305 6.76033C59.7421 6.76033 58.0736 8.90806 58.0736 12.1385C58.0736 15.156 59.7243 16.8777 62.5998 16.8777C63.8245 16.8777 65.1912 16.576 66.274 16.008V14.0023C65.28 14.517 64.0198 14.8365 62.8838 14.8365C61.3928 14.8365 60.6295 14.2508 60.452 12.6533H67.0195C67.0372 12.2983 67.055 11.961 67.055 11.5528ZM62.6885 8.80156C64.0198 8.80156 64.5522 9.3518 64.6942 10.9138H60.452C60.6295 9.36955 61.304 8.80156 62.6885 8.80156ZM75.2136 6.76033C73.8647 6.76033 72.7287 7.47032 71.8412 8.71281L71.5572 6.93783H69.7645V16.7002H72.0187V10.2393C72.9417 9.10331 73.5629 8.67731 74.4504 8.67731C75.4444 8.67731 75.8526 9.20981 75.8526 10.257V16.7002H78.0891V9.8843C78.0891 7.82532 77.0064 6.76033 75.2136 6.76033ZM89.709 16.7002L89.1943 13.9135V10.0618C89.1943 8.03832 87.8453 6.76033 85.4845 6.76033C84.4196 6.76033 83.1416 7.02658 81.8636 7.48807V9.51155C82.9996 8.97906 83.9758 8.74831 85.0763 8.74831C86.3543 8.74831 86.94 9.26305 86.94 10.4345V10.5943C82.5558 10.6298 80.9051 11.9433 80.9051 14.1265C80.9051 15.8305 81.9701 16.8777 83.9581 16.8777C85.449 16.8777 86.4963 16.292 87.1885 15.1205L87.4903 16.7002H89.709ZM84.6503 14.872C83.6563 14.872 83.2481 14.446 83.2481 13.7183C83.2481 12.5645 84.2421 12.0675 86.94 12.0498V12.7065C86.94 14.0378 86.0348 14.872 84.6503 14.872ZM95.0987 13.452V16.7002H98.1162V13.452H95.0987Z"
-      />
-    </Icon>
+      Building Tia at Intripid
+    </Text>
+  </HStack>
+);
+
+const NavLink = ({ label, href, isActive, isMobile }) => (
+  <Link href={href} passHref>
+    <Text
+      as="span"
+      fontSize={isMobile ? "11px" : "12px"}
+      fontFamily="MonolisaRegular"
+      color={isActive ? "white" : "ash"}
+      _hover={{ color: "white" }}
+      transition="color 0.15s ease"
+      cursor="pointer"
+    >
+      {label}
+    </Text>
   </Link>
 );
 
-const Links = ({ isMobile }) => {
-  return (
-    <Stack direction="row" spacing={isMobile ? "4" : "20"}>
-      <Link href="/" passHref>
-        <CustomButton variant="ghost" color={isMobile ? "white" : "ash"}>Home</CustomButton>
-      </Link>
-      <Link href="/about" passHref>
-        <CustomButton variant="ghost" color={isMobile ? "white" : "ash"}>About</CustomButton>
-      </Link>
-      <Link href="/blog" passHref>
-        <CustomButton variant="ghost" color={isMobile ? "white" : "ash"}>Blog</CustomButton>
-      </Link>
-    </Stack>
-  );
+const isActivePath = (current, href) => {
+  if (href === "/") return current === "/";
+  return current === href || current.startsWith(href + "/");
 };
 
 const Header = () => {
+  const router = useRouter();
+  const current = router.pathname;
+
   return (
     <>
-      <Container
-        maxW="full"
+      {/* Desktop chrome bar */}
+      <Box
         display={{ base: "none", md: "block" }}
         position="sticky"
-        zIndex="10"
         top="0"
+        zIndex="10"
+        borderBottom="1px solid"
+        borderColor="whiteAlpha.100"
+        bg="rgba(11, 11, 11, 0.7)"
         style={{ backdropFilter: "saturate(180%) blur(20px)" }}
-        py="4"
       >
-        <Flex>
-          <CustomButton variant="ghost">
-            <FavIcon />
-          </CustomButton>
-          <Spacer />
-          <Links isMobile={false} />
-        </Flex>
-      </Container>
+        <Container maxW="1080px" mx="auto" px={4}>
+          <Flex h="48px" align="center">
+            <HStack spacing={3}>
+              <Link href="/" passHref>
+                <Text
+                  as="span"
+                  fontSize="13px"
+                  fontFamily="MonolisaBold"
+                  color="white"
+                  cursor="pointer"
+                  letterSpacing="-0.3px"
+                >
+                  sreenivas
+                </Text>
+              </Link>
+              <StatusChip />
+            </HStack>
+            <Spacer />
+            <HStack spacing={6}>
+              {NAV_ITEMS.map((item) => (
+                <NavLink
+                  key={item.href}
+                  label={item.label}
+                  href={item.href}
+                  isActive={isActivePath(current, item.href)}
+                />
+              ))}
+            </HStack>
+          </Flex>
+        </Container>
+      </Box>
 
-      <Container display={{ base: "block", md: "none" }} p={4}>
-        <Center>
-          <FavIcon />
-        </Center>
-      </Container>
+      {/* Mobile top: name + status */}
+      <Box
+        display={{ base: "block", md: "none" }}
+        px={4}
+        pt={4}
+        pb={3}
+      >
+        <HStack spacing={3} align="center">
+          <Link href="/" passHref>
+            <Text
+              as="span"
+              fontSize="13px"
+              fontFamily="MonolisaBold"
+              color="white"
+              cursor="pointer"
+            >
+              sreenivas
+            </Text>
+          </Link>
+          <StatusChip />
+        </HStack>
+      </Box>
 
-      <Container
-        maxW="full"
+      {/* Mobile bottom dock */}
+      <Box
         display={{ base: "block", md: "none" }}
         position="fixed"
         left="0"
+        right="0"
         bottom="0"
-        bg="#0B0B0B"
+        bg="rgba(11, 11, 11, 0.92)"
         borderTop="1px solid"
         borderColor="whiteAlpha.100"
         zIndex="99"
-        py={2}
+        style={{ backdropFilter: "saturate(180%) blur(20px)" }}
+        py={3}
       >
-        <Center>
-          <Links isMobile={true} />
-        </Center>
-      </Container>
+        <Flex justify="space-around" align="center" px={2}>
+          {NAV_ITEMS.map((item) => (
+            <NavLink
+              key={item.href}
+              label={item.label}
+              href={item.href}
+              isActive={isActivePath(current, item.href)}
+              isMobile
+            />
+          ))}
+        </Flex>
+      </Box>
     </>
   );
 };

--- a/src/lib/craft.js
+++ b/src/lib/craft.js
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+const CRAFT_PATH = path.join(process.cwd(), "content/craft");
+
+export function getCraftSlugs() {
+  if (!fs.existsSync(CRAFT_PATH)) return [];
+  return fs.readdirSync(CRAFT_PATH).filter((p) => /\.mdx?$/.test(p));
+}
+
+export function getCraftBySlug(slug) {
+  const realSlug = slug.replace(/\.mdx?$/, "");
+  const fullPath = path.join(CRAFT_PATH, `${realSlug}.mdx`);
+  const fileContents = fs.readFileSync(fullPath, "utf8");
+  const { data, content } = matter(fileContents);
+
+  return { slug: realSlug, frontmatter: data, content };
+}
+
+export function getAllCraft() {
+  const slugs = getCraftSlugs();
+  const items = slugs
+    .map((slug) => getCraftBySlug(slug))
+    .sort((a, b) =>
+      a.frontmatter.date > b.frontmatter.date ? -1 : 1
+    );
+  return items;
+}


### PR DESCRIPTION
… builder

Reframes the site from "portfolio" to "product builder hub":

- New chrome bar header (Linear/Lee Robinson style) — sticky thin row with monogram, live status chip ("● Building Tia at Intripid"), text-only nav. Mobile gets matching top status row + bottom dock with all 5 routes.
- New hero copy: "I build software products end-to-end. Currently building Tia at Intripid, writing about AI, and shipping experiments on the side."
- Contact stack now vertical and left-aligned: CTA buttons → social icons.
- Added Tia by Intripid to Data.js as the current top project (2025-26).
- New /craft route — grid index of experiments with status dots (wip/shipped/exploring), tags, dates. /craft/[slug] detail pages with rich frontmatter (demo + source links, status, tags). Sample entry: openclaw-shell-agent.mdx.
- New /now page (Derek Sivers-style) — building, focus, shipping, reading, saying-no-to. Updated monthly. Uses NOW_DATA constant for easy edits.
- TODO.md tracking unspecified items: subdomain previous versions, photo gallery, Brian Lovin-style work case studies, /stack page, view transitions, ⌘K palette, RSS feed, real Tia assets.

https://claude.ai/code/session_01HxcZqapd2AeYvbHW6ZLGhi